### PR TITLE
Allow more content types

### DIFF
--- a/lib/rapidash/response.rb
+++ b/lib/rapidash/response.rb
@@ -8,7 +8,6 @@ module Rapidash
       def new(response)
         return nil unless response.body
         type = response.headers["content-type"]
-        if type.include?("application/json")
           body = JSON.parse(response.body)
           if body.kind_of?(Hash)
             return Hashie::Mash.new(body)
@@ -19,9 +18,8 @@ module Rapidash
             end
             return output
           end
-        else
-          raise ParseError.new("Cannot parse content type: #{response.headers["content-type"]}")
-        end
+      rescue JSON::ParserError => e
+        raise ParseError.new("Failed to parse content for type: #{response.headers["content-type"]}")
       end
     end
 

--- a/spec/rapidash/response_spec.rb
+++ b/spec/rapidash/response_spec.rb
@@ -11,6 +11,26 @@ def valid_response_object
   })
 end
 
+def valid_html_response_object
+  body = {"foo" => "bar" }.to_json
+  OpenStruct.new({
+    :headers => {
+      "content-type" => "text/html"
+    },
+    :body => body
+  })
+end
+
+def valid_js_response_object
+  body = {"foo" => "bar" }.to_json
+  OpenStruct.new({
+    :headers => {
+      "content-type" => "text/javascript"
+    },
+    :body => body
+  })
+end
+
 
 def valid_response_array
   body = [{"foo" => "bar" }, {"baz" => "bra"}].to_json
@@ -32,6 +52,15 @@ def invalid_response
   })
 end
 
+def invalid_js_response_object
+  OpenStruct.new({
+    :headers => {
+      "content-type" => "text/javascript"
+    },
+    :body => "<xml>something</xml>"
+  })
+end
+
 def nil_response
   OpenStruct.new({
     :body => nil
@@ -45,6 +74,16 @@ describe Rapidash::Response do
       response = Rapidash::Response.new(valid_response_object)
       response.foo.should eql("bar")
     end
+    
+    it "should parse JSON Objects returned with javascript type" do
+      response = Rapidash::Response.new(valid_js_response_object)
+      response.foo.should eql("bar")
+    end
+    
+    it "should parse JSON Objects returned with html type" do
+      response = Rapidash::Response.new(valid_html_response_object)
+      response.foo.should eql("bar")
+    end        
 
     it "should parse JSON Arrays" do
       response = Rapidash::Response.new(valid_response_array)
@@ -63,6 +102,12 @@ describe Rapidash::Response do
         Rapidash::Response.new(invalid_response)
       }.to raise_error(Rapidash::ParseError)
     end
+    
+    it "should raise an error on a non-json response body" do
+      expect {
+        Rapidash::Response.new(invalid_js_response_object)
+      }.to raise_error(Rapidash::ParseError)
+    end    
   end
 
 


### PR DESCRIPTION
addresses issue #2

To avoid errors on content-type of api when valid json response changed to catch error on JSON parse. 

Sample code for api that returns text/javascript. 

``` ruby
require 'rapidash'

class Stores < Rapidash::Base

  def store!(owner)
    self.url = "/#{owner}/store"
    call!
  end
end

class Client < Rapidash::Client
  method :http
  resource :stores #An array can be passed through
  extension "js"
  site "http://api.bigcartel.com/"
end


client = Client.new
p client.stores.store!("ugmonk")
```
