### PR TITLE
Feature: Resource method on resourceable classes

### DIFF
--- a/lib/rapidash/base.rb
+++ b/lib/rapidash/base.rb
@@ -23,7 +23,7 @@ module Rapidash
 
       @options ||= {}
       @options.merge!(options || {})
-      @url = "#{base_url}#{self.class.to_s.split("::")[-1].downcase.pluralize}"
+      @url = "#{base_url}#{resource_url}"
       @url += "/#{@id}" if @id
     end
 
@@ -54,6 +54,7 @@ module Rapidash
       client.send(method, url, options)
     end
 
+
     private
 
     def set_body!(params)
@@ -67,6 +68,10 @@ module Rapidash
     def base_url
       old_url = self.options[:previous_url]
       old_url ? "#{old_url}/" : ""
+    end
+
+    def resource_url
+      self.options[:url] || self.class.to_s.split("::")[-1].downcase.pluralize
     end
   end
 end

--- a/lib/rapidash/resourceable.rb
+++ b/lib/rapidash/resourceable.rb
@@ -4,6 +4,21 @@ module Rapidash
       base.extend ClassMethods
     end
 
+    def resource(name, id = nil, options = {})
+      options[:url] ||= name
+      if self.respond_to?(:url)
+        options = {:previous_url => self.url}.merge!(options)
+      end
+      client = self
+      client = self.client if self.respond_to?(:client)
+      Rapidash::Base.new(client, id, options)
+    end
+
+    def resource!(*args)
+      self.resource(*args).call!
+    end
+
+
     module ClassMethods
       def resource(*names)
         options = names.extract_options!

--- a/spec/rapidash/base_spec.rb
+++ b/spec/rapidash/base_spec.rb
@@ -142,4 +142,16 @@ describe Rapidash::Base do
     end
   end
 
+  describe ".resource_url" do
+    it "should return the class name as a url if none is specified" do
+      subject.send(:resource_url).should eql("basetesters")
+    end
+
+    it "should return the previous url if set" do
+      subject.options = {:url => "people"}
+      subject.send(:resource_url).should eql("people")
+    end
+  end
+
+
 end

--- a/spec/rapidash/resourceable_spec.rb
+++ b/spec/rapidash/resourceable_spec.rb
@@ -58,6 +58,62 @@ describe Rapidash::Resourceable do
 
   end
 
+
+  describe "instance methods" do
+    let(:client) { ClientTester.new }
+
+    describe ".resource" do
+
+
+      it "should create a Rapidash::Base" do
+        client.resource(:users, 1).class.should eql(Rapidash::Base)
+      end
+
+      it "should set the url to the resource name" do
+        resource = client.resource(:users)
+        resource.url.should eql("users")
+      end
+
+      it "should pass the id through if specified" do
+        resource = client.resource(:users, 1)
+        resource.url.should eql("users/1")
+      end
+
+      it "should pass the previous url through" do
+        def client.url
+          "base"
+        end
+        resource = client.resource(:users, 1)
+        resource.url.should eql("base/users/1")
+      end
+
+      it "should pass the client through" do
+        resource = client.resource(:users, 1)
+        resource.client.should eql(client)
+      end
+
+      it "should allow an explicit url to be sent" do
+        resource = client.resource(:users, 1, :url => "people")
+        resource.url.should eql("people/1")
+      end
+
+      it "should be chainable" do
+        resource = client.resource(:users, 1).resource(:comments, 2)
+        resource.url.should eql("users/1/comments/2")
+        resource.client.should eql(client)
+      end
+    end
+
+    describe ".resource!" do
+      it "should call the call! method on a resource" do
+        resource = mock
+        Rapidash::Base.stub(:new).and_return(resource)
+        resource.should_receive(:call!)
+        client.resource!(:users, 1)
+      end
+    end
+  end
+
   describe "#resource" do
     it "should add a method with the name of the argument" do
       Rapidash::ClientTester.new.methods.map { |m| m.to_sym }.should include(:users)


### PR DESCRIPTION
To save a user from having to define a class for every resource, they
can call the resource method to create one on the fly.

```
client.resource!(:users, 1) #Makes a call to /users/1
```

This can be chained

```
client.resource(:users, 1).resource!(:repos, 2) #Makes a call to /users/1/repos/2
```

This feature was requested by @mli-max in #4
