### PR TITLE
Fix issue with ResponseError not exposing it's `message` method publicly

### DIFF
--- a/lib/rapidash/response_error.rb
+++ b/lib/rapidash/response_error.rb
@@ -55,12 +55,10 @@ module Rapidash
       @method = response[:method].to_s.upcase
       @url = response[:url]
 
-      super(message)
+      super
     end
 
-    private
-
-    def message
+    def to_s
       msg = "#{status} #{method} #{url}"
 
       if respond_to?(:errors) && !(errors.blank?)


### PR DESCRIPTION
This was causing a further exception when raising the `ResponseError` exception saying

```
rspec-core-2.13.1/lib/rspec/core/formatters/base_text_formatter.rb:264:in `dump_failure_info': 
private method `message' called for #<Bcx::ResponseError:0x007fcadbe08960> (NoMethodError)

```

Changed to use the standard `to_s` which is automatically called when raising.
