### PR TITLE
Default options for all http requests

### DIFF
--- a/lib/rapidash/http_client.rb
+++ b/lib/rapidash/http_client.rb
@@ -4,11 +4,15 @@ require 'faraday_middleware/multi_json'
 
 module Rapidash
   module HTTPClient
-    attr_accessor :login, :password
+    attr_accessor :login, :password, :request_default_options
     attr_writer :connection
 
+    # Provide login and password fields for basic HTTP authentication
+    # Provide request_default_options field for default options to be provided on each http request
+    # To set a default User-agent which identifies your application, provide
+    # { request_default_options: { header: { user_agent: 'My great new App V.0.1   Contact: me@me.com'} } }
     def initialize(options = {})
-      [:login, :password].each do |key|
+      [:login, :password, :request_default_options].each do |key|
         self.send("#{key.to_s}=".to_sym, options[key])
       end
     end
@@ -26,6 +30,7 @@ module Rapidash
     end
 
     def request(verb, url, options = {})
+      options.merge!(self.request_default_options) if self.request_default_options
       url = connection.build_url(normalize_url(url), options[:params]).to_s
       response = connection.run_request(verb, url, options[:body], options[:header])
 

--- a/spec/rapidash/base_spec.rb
+++ b/spec/rapidash/base_spec.rb
@@ -122,6 +122,13 @@ describe Rapidash::Base do
       subject.call!
     end
 
+    it "should set extra headers on the client" do
+      user_agent_header = {header: { user_agent: 'My own Faraday version'}}
+      subject = BaseTester.new(client,user_agent_header)
+      subject.url = "tester/1"
+      allow(client).to receive(:get).with("tester/1", {:headers => headers}.merge(user_agent_header) )
+      subject.call!
+    end
 
     it "should call a post on the client if set" do
       allow(client).to receive(:post).with("tester", {:headers => headers})

--- a/spec/rapidash/http_client_spec.rb
+++ b/spec/rapidash/http_client_spec.rb
@@ -66,5 +66,16 @@ describe Rapidash::HTTPClient do
       allow(subject.connection).to receive(:run_request).with(:get, "http://example.com/foo", nil, nil).and_return(response)
       subject.request(:get, "foo")
     end
+
+    describe "default options" do
+      let!(:subject) { HTTPTester.new(request_default_options: { header: { user_agent: 'New app v1.0'} } ) }
+
+      it "should provide default headers in the request" do
+        response = double(:body => "response")
+        allow(subject.connection).to receive(:run_request).with(:get, "http://example.com/foo", nil, {:user_agent=>"New app v1.0"}).and_return(response)
+        subject.request(:get, "foo")
+      end
+    end
+
   end
 end

--- a/spec/rapidash/urlable_spec.rb
+++ b/spec/rapidash/urlable_spec.rb
@@ -19,6 +19,7 @@ end
 describe Rapidash::Urlable do
 
   let!(:client) { double }
+  let(:custom_header) { { :header => { user_agent: 'Experimentation v3.14'} } }
 
   describe "#included" do
     it "should add the url method" do
@@ -35,6 +36,12 @@ describe Rapidash::Urlable do
     it "should set options on the class" do
       api = ApiTester.new(client, :option1 => "foo")
       expect(api.instance_variable_get(:@options)).to eql({:option1 => "foo"})
+      expect(api.instance_variable_get(:@url)).to eql("foo")
+    end
+
+    it "should allow custom headers" do
+      api = ApiTester.new(client,custom_header)
+      expect(api.instance_variable_get(:@options)).to eql(custom_header)
       expect(api.instance_variable_get(:@url)).to eql("foo")
     end
 


### PR DESCRIPTION
Adding possibility to provide default options to use on all http requests. One use case is to provide a user-agent identifying the application to the 3rd party.

Also, added some tests showing how to add request headers to resources requests. These are only tests and don't provide much value, can be removed (that's commit 33a89dd)
